### PR TITLE
Fix for output folders located in a subdirectory, e.g. target/classes

### DIFF
--- a/org.ant4eclipse.lib.pde/src/org/ant4eclipse/lib/pde/model/validator/OutputPathValidator.java
+++ b/org.ant4eclipse.lib.pde/src/org/ant4eclipse/lib/pde/model/validator/OutputPathValidator.java
@@ -61,7 +61,7 @@ public class OutputPathValidator extends AbstractProjectValidator {
           EclipseProject.PathStyle.PROJECT_RELATIVE_WITHOUT_LEADING_PROJECT_NAME);
       Set<String> jdtoutputpathes = new HashSet<String>();
       for (File outputfolder : outputfolders) {
-        jdtoutputpathes.add(outputfolder.getName().replace('\\', '/'));
+        jdtoutputpathes.add(outputfolder.getPath().replace('\\', '/'));
       }
 
       PluginBuildProperties buildproperties = pluginrole.getBuildProperties();


### PR DESCRIPTION
The behavior for non-nested folders is unchanged, as the File.getPath()
method will preserve relative paths.
