### PR TITLE
not all temp files get deleted / old javadoc removed

### DIFF
--- a/org.ant4eclipse.lib.core/src/org/ant4eclipse/lib/core/util/Utilities.java
+++ b/org.ant4eclipse.lib.core/src/org/ant4eclipse/lib/core/util/Utilities.java
@@ -1014,6 +1014,7 @@ public class Utilities {
     try {
       File result = File.createTempFile("a4e", suffix);
       writeFile(result, content, encoding);
+      result.deleteOnExit();
       return result.getCanonicalFile();
     } catch (IOException ex) {
       A4ELogging.debug("Temp dir: %s", System.getProperty("java.io.tmpdir"));
@@ -1114,7 +1115,6 @@ public class Utilities {
    *          the jar file to expand
    * @param expansionDirectory
    *          the expansion directory
-   * @throws IOException
    */
   public static synchronized final void expandJarFile(JarFile jarFile, File expansionDirectory) {
 


### PR DESCRIPTION
running ant4eclipse a while produces lots of a4e<random number>.py files, because temp files are not created for deletion on exit in the Utilities.java.

While fixing this a declared exception in the javadoc which is not actually included in the throw clause of the function was removed also.

best regards
Christoph
