### PR TITLE
Problems with java dir

### DIFF
--- a/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/JavaExecuter.java
+++ b/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/JavaExecuter.java
@@ -317,8 +317,7 @@ public class JavaExecuter {
         cmd.append("\"");
       }
     }
-    String result = cmd.toString();
-    return result;
+    return cmd.toString();
   }
 
   /**


### PR DESCRIPTION
So, recently I was in problems with ant4eclipse. By some reason, in one of our Windows hudson machines, some plugins project are failing with the message: "Cannot run program "C:\Program": CreateProcess error=2, The system cannot find the file specified".

The error was obvious right? My java was in "Program Files" dir, and it has a space char in it, so, I made this change to work with any acceptable dir. 

I'm hope it help you. Thanks.
