### PR TITLE
passing defaultCompilerOptionsFile macro parameter to sub-feature build

### DIFF
--- a/org.ant4eclipse.ant.pde/macros/a4e-pde-macros.xml
+++ b/org.ant4eclipse.ant.pde/macros/a4e-pde-macros.xml
@@ -975,6 +975,7 @@
 					              platformConfigurationId="@{platformConfigurationId}"
 					              destination="@{destination}"
 					              packageAsJar="@{packageAsJar}"
+								  defaultCompilerOptionsFile="@{defaultCompilerOptionsFile}"
 					              useEcj="@{useEcj}"
 					              skipBuildPlugins="@{skipBuildPlugins}"
 					              debug="@{debug}" />


### PR DESCRIPTION
as stated in the commit message.
for sub.feature builds with customized jft preference file it ist necessary to pass the location of the preference to each sub-feature build, otherwise the default jft preference will be applied
