### PR TITLE
Support for autodiscovery of JVMs

### DIFF
--- a/org.ant4eclipse.ant.jdt/src/org/ant4eclipse/ant/antlib.xml
+++ b/org.ant4eclipse.ant.jdt/src/org/ant4eclipse/ant/antlib.xml
@@ -4,6 +4,7 @@
   <typedef name="userLibraries"                 classname="org.ant4eclipse.ant.jdt.type.UserLibraryPath" />
   <typedef name="installedJREs"                 classname="org.ant4eclipse.ant.jdt.type.JreContainer" />
   <typedef name="jre"                           classname="org.ant4eclipse.ant.jdt.type.JreContainer$Runtime" />
+  <typedef name="jreAutodiscover"               classname="org.ant4eclipse.ant.jdt.type.JreContainer$AutoDiscover" />
   <typedef name="customExecutionEnvironment"    classname="org.ant4eclipse.ant.jdt.type.ExecutionEnvironmentDefinitionDataType" />
   <typedef name="jdtClassPathVariable"          classname="org.ant4eclipse.ant.jdt.type.JdtClassPathVariableType" />
   <typedef name="jdtClassPathLibrary"           classname="org.ant4eclipse.ant.jdt.type.JdtClassPathContainerType" />


### PR DESCRIPTION
Allows to autodiscover JVMs located inside an installation directory.

Instead of hardcode path like this:
`	<ant4eclipse:installedJREs>
		<jre id="jdk16" location="/opt/java/jdk1.6.0_23-amd64" />
	</ant4eclipse:installedJREs>`

you can now let ant4eclipse autodiscover those (example includes all installed 64bit JVMs)

`	<ant4eclipse:installedJREs>
		<jreAutodiscover>
			<dirset dir="/opt/java">
				<include name="*-amd64"/>
				<include name="*-x64"/>
			</dirset>
		</jreAutodiscover>
	</ant4eclipse:installedJREs>`

to make this feature more useable some more enhancements are required but I'll try offer them as seperate pull requests. One open point for example is A4E seems to ignore the Bundle-RequiredExecutionEnvironment if no explicit class-path entries like `<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>` is defined
and simply choose the first JRE it finds instead of searching for a compatible one...