### PR TITLE
Prevent using a temp file by reading output of process directly

### DIFF
--- a/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/JavaExecuter.java
+++ b/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/JavaExecuter.java
@@ -219,7 +219,7 @@ public class JavaExecuter {
   }
 
   /**
-   * @throws IOException
+   * start the vm, read the result and wait fro the process to finish
    */
   public void execute() {
 

--- a/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/JavaRuntimeLoader.java
+++ b/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/JavaRuntimeLoader.java
@@ -24,7 +24,6 @@ import org.ant4eclipse.lib.core.data.Version;
 import org.ant4eclipse.lib.core.exception.Ant4EclipseException;
 import org.ant4eclipse.lib.core.logging.A4ELogging;
 import org.ant4eclipse.lib.core.service.ServiceRegistryAccess;
-import org.ant4eclipse.lib.core.util.Utilities;
 import org.ant4eclipse.lib.jdt.JdtExceptionCode;
 import org.ant4eclipse.lib.jdt.internal.model.jre.support.LibraryDetector;
 import org.ant4eclipse.lib.jdt.model.jre.JavaProfile;
@@ -62,29 +61,11 @@ public class JavaRuntimeLoader {
     Assure.nonEmpty("id", id);
     Assure.isDirectory("location", location);
 
-    String outfileName = System.getProperty("java.io.tmpdir") + File.separatorChar + "ant4eclipse_jdk_props_"
-        + Math.round(Math.random() * 1000000000);
-    // System.out.println(outfileName);
-
     JavaExecuter javaLauncher = JavaExecuter.createWithA4eClasspath(location);
     javaLauncher.setMainClass(LibraryDetector.class.getName());
-    javaLauncher.setArgs(new String[] { outfileName });
-
     javaLauncher.execute();
+    String[] values = javaLauncher.getSystemOut();
 
-    // TODO
-    StringBuffer contents = new StringBuffer();
-    try {
-      File file = new File(outfileName);
-      contents = Utilities.readTextContent(file, Utilities.ENCODING, false);
-      file.deleteOnExit();
-    } catch (Throwable e) {
-      e.printStackTrace();
-    }
-
-    String result = contents.toString();
-    // System.out.println(result);
-    String[] values = result.split("\\|");
     Version javaVersion = Version.newStandardVersion(values[0]);
     String sunbootclasspath = values[1];
     String javaextdirs = (extDirs != null ? extDirs : values[2]);
@@ -103,8 +84,6 @@ public class JavaRuntimeLoader {
     }
 
     File[] libraries = files.toArray(new File[0]);
-
-    //
     Properties properties = new Properties();
     properties.put(JAVA_SPECIFICATION_VERSION, values[4]);
     properties.put(JAVA_SPECIFICATION_NAME, values[5]);

--- a/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/support/LibraryDetector.java
+++ b/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/support/LibraryDetector.java
@@ -11,59 +11,32 @@
  **********************************************************************/
 package org.ant4eclipse.lib.jdt.internal.model.jre.support;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-
 /**
  * Used to discover the boot path, extension directories, and endorsed directories for a Java VM.
  */
 public class LibraryDetector {
 
   /**
-   * Prints system properties to a file that must be specified in args[0].
+   * Prints system properties to std.out
    * <ul>
    * <li>java.version</li>
    * <li>sun.boot.class.path</li>
    * <li>java.ext.dirs</li>
    * <li>java.endorsed.dirs</li>
+   * <li>java.specification.version</li>
+   * <li>java.specification.name</li>
+   * <li>java.vendor</li>
    * </ul>
    * 
    * @param args
    */
   public static void main(String[] args) {
-
-    // create property string
-    StringBuffer buffer = new StringBuffer();
-    buffer.append(System.getProperty("java.version"));
-    buffer.append("|");
-    buffer.append(System.getProperty("sun.boot.class.path"));
-    buffer.append("|");
-    buffer.append(System.getProperty("java.ext.dirs"));
-    buffer.append("|");
-    buffer.append(System.getProperty("java.endorsed.dirs"));
-    buffer.append("|");
-    buffer.append(System.getProperty("java.specification.version"));
-    buffer.append("|");
-    buffer.append(System.getProperty("java.specification.name"));
-    buffer.append("|");
-    buffer.append(System.getProperty("java.vendor"));
-
-    // dump for logging purpose
-    System.out.println(buffer.toString());
-
-    // write to file
-    try {
-      File outfile = new File(args[0]);
-      BufferedWriter out = new BufferedWriter(new FileWriter(outfile));
-      out.write(buffer.toString());
-      out.close();
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-    //
-    // // exit
-    // System.exit(0);
+    System.out.println(System.getProperty("java.version", ""));
+    System.out.println(System.getProperty("sun.boot.class.path", ""));
+    System.out.println(System.getProperty("java.ext.dirs", ""));
+    System.out.println(System.getProperty("java.endorsed.dirs", ""));
+    System.out.println(System.getProperty("java.specification.version", ""));
+    System.out.println(System.getProperty("java.specification.name", ""));
+    System.out.println(System.getProperty("java.vendor", ""));
   }
 }


### PR DESCRIPTION
TO detect the java-version of the jre currently a process is started and then a new file is written. This file is the read back by ant4eclipse and splited into lines.

This be simplified by just let the process write to std.out and read this from the process directly (what is already possible). This prevents additional I/O and file creation.

Also the Libary detector directly printing each information in one line prevents the need for a seperator and extra splitting.