### PR TITLE
first mark the file as delete before try to write to it

### DIFF
--- a/org.ant4eclipse.lib.core/src/org/ant4eclipse/lib/core/util/Utilities.java
+++ b/org.ant4eclipse.lib.core/src/org/ant4eclipse/lib/core/util/Utilities.java
@@ -877,7 +877,8 @@ public class Utilities {
       writechannel = outstream.getChannel();
       readchannel.transferTo(0, readchannel.size(), writechannel);
     } catch (IOException ex) {
-      throw new Ant4EclipseException(ex, CoreExceptionCode.COPY_FAILURE, source.getAbsolutePath(), to.getAbsolutePath());
+      throw new Ant4EclipseException(ex, CoreExceptionCode.COPY_FAILURE, source.getAbsolutePath(),
+          to.getAbsolutePath());
     } finally {
       close(readchannel);
       close(writechannel);
@@ -1015,8 +1016,8 @@ public class Utilities {
     Assure.nonEmpty("encoding", encoding);
     try {
       File result = File.createTempFile("a4e", suffix);
-      writeFile(result, content, encoding);
       result.deleteOnExit();
+      writeFile(result, content, encoding);
       return result.getCanonicalFile();
     } catch (IOException ex) {
       A4ELogging.debug("Temp dir: %s", System.getProperty("java.io.tmpdir"));
@@ -1246,7 +1247,8 @@ public class Utilities {
       int result = process.waitFor();
       if (result != 0) {
         A4ELogging.error(CoreExceptionCode.LAUNCHING_FAILURE.getMessage(), exe, Integer.valueOf(result), output, error);
-        throw new Ant4EclipseException(CoreExceptionCode.LAUNCHING_FAILURE, exe, Integer.valueOf(result), output, error);
+        throw new Ant4EclipseException(CoreExceptionCode.LAUNCHING_FAILURE, exe, Integer.valueOf(result), output,
+            error);
       }
 
     } catch (Exception ex) {


### PR DESCRIPTION
If writeFile(result, content, encoding) fails then the temp file is not marked for deletion at all and thus can be stay stale in the tmp directory. So marking the file as soon as possible as "deleteOnExit" prevents this.

The rest of the "changes" are only cause by the formater for some reason :-(