### PR TITLE
Communication concurrency problem in inter-process communication

### DIFF
--- a/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/JavaExecuter.java
+++ b/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/JavaExecuter.java
@@ -275,6 +275,9 @@ public class JavaExecuter {
       // wait for result
       proc.waitFor();
 
+      errorGobbler.join();
+      outputGobbler.join();
+
       // read out and err stream
       this._systemOut = outputLinesList.toArray(new String[0]);
       this._systemErr = errorLinesList.toArray(new String[0]);


### PR DESCRIPTION
When the result of a forked process should be inspected, one must make
sure that the observer threads have completed their work before
accessing their results. Otherwise, builds suffer from spradic failures like:
```
java.lang.ArrayIndexOutOfBoundsException: 0
	at org.ant4eclipse.lib.jdt.internal.model.jre.JavaRuntimeLoader.loadJavaRuntime(JavaRuntimeLoader.java:71)
	at org.ant4eclipse.lib.jdt.internal.model.jre.JavaRuntimeRegistryImpl.registerJavaRuntime(JavaRuntimeRegistryImpl.java:79)
	at org.ant4eclipse.ant.jdt.type.JreContainer.createJavaRuntime(JreContainer.java:116)
	at org.ant4eclipse.ant.jdt.type.JreContainer.addConfiguredJre(JreContainer.java:96)
```