### PR TITLE
Java 11 support

### DIFF
--- a/org.ant4eclipse.ant.jdt/src/org/ant4eclipse/ant/jdt/type/JreContainer.java
+++ b/org.ant4eclipse.ant.jdt/src/org/ant4eclipse/ant/jdt/type/JreContainer.java
@@ -114,7 +114,7 @@ public class JreContainer extends AbstractAnt4EclipseDataType {
     List<File> jreFiles = getSelectedJreFiles(runtime);
 
     JavaRuntime javaRuntime = javaRuntimeRegistry.registerJavaRuntime(runtime.getId(), runtime.getLocation(),
-        runtime.getExtDirs(), runtime.getEndorsedDirs(), jreFiles);
+        runtime.getExtDirs(), runtime.getEndorsedDirs(), jreFiles, runtime.getProfile());
 
     Assure.notNull("javaRuntime", javaRuntime);
 
@@ -194,6 +194,8 @@ public class JreContainer extends AbstractAnt4EclipseDataType {
 
     private List<FileSet> _fileSets;
 
+    private String        _profile;
+
     public String getId() {
       return this._id;
     }
@@ -244,6 +246,24 @@ public class JreContainer extends AbstractAnt4EclipseDataType {
 
     public boolean hasFileSets() {
       return this._fileSets != null;
+    }
+
+    /**
+     * The profile name to use as alternative for the profile name provided by the runtime.
+     * 
+     * <p>
+     * Use this option, if ant4eclipse does not support the profile of your Java runtime.
+     * </p>
+     */
+    public String getProfile() {
+      return this._profile;
+    }
+
+    /**
+     * @see #getProfile()
+     */
+    public void setProfile(String profile) {
+      this._profile = profile;
     }
   }
 } /* ENDCLASS */

--- a/org.ant4eclipse.lib.core/src/org/ant4eclipse/lib/core/data/Version.java
+++ b/org.ant4eclipse.lib.core/src/org/ant4eclipse/lib/core/data/Version.java
@@ -131,6 +131,9 @@ public class Version implements Comparable<Version> {
           if (firstpos == -1) {
             // no delimiter
             this._micro = Integer.valueOf(microWithQualifier);
+            if (st.hasMoreTokens()) {
+              this._qualifier = st.nextToken();
+            }
           } else {
             // with delimiter separating the qualifier
             this._micro = Integer.valueOf(microWithQualifier.substring(0, firstpos));

--- a/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/JavaRuntimeLoader.java
+++ b/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/JavaRuntimeLoader.java
@@ -57,9 +57,11 @@ public class JavaRuntimeLoader {
    * @param files
    *          the list of (jar-)files defining this java runtime or null if the file should be determined from the
    *          JavaRuntime's location
+   * @param profile
+   *          Optional alternative profile to use.
    */
   public static JavaRuntime loadJavaRuntime(String id, File location, String extDirs, String endorsedDirs,
-      List<File> files) {
+      List<File> files, String profile) {
     Assure.nonEmpty("id", id);
     Assure.isDirectory("location", location);
 
@@ -90,7 +92,7 @@ public class JavaRuntimeLoader {
     properties.put(JAVA_SPECIFICATION_VERSION, values[4]);
     properties.put(JAVA_SPECIFICATION_NAME, values[5]);
 
-    String javaProfileName = getVmProfile(properties);
+    String javaProfileName = profile == null ? getVmProfile(properties) : profile;
     JavaRuntimeRegistry javaRuntimeRegistry = ServiceRegistryAccess.instance().getService(JavaRuntimeRegistry.class);
     if (!javaRuntimeRegistry.hasJavaProfile(javaProfileName)) {
       A4ELogging.error("No Java-Profile with name '%s' found for JRE '%s' located at '%s'. Known Profiles: '%s'",

--- a/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/JavaRuntimeRegistryImpl.java
+++ b/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/internal/model/jre/JavaRuntimeRegistryImpl.java
@@ -11,7 +11,7 @@
  **********************************************************************/
 package org.ant4eclipse.lib.jdt.internal.model.jre;
 
-import static org.ant4eclipse.lib.core.logging.A4ELogging.trace;
+import static org.ant4eclipse.lib.core.logging.A4ELogging.*;
 
 import java.io.File;
 import java.util.Collection;
@@ -59,7 +59,7 @@ public class JavaRuntimeRegistryImpl implements JavaRuntimeRegistry {
    * {@inheritDoc}
    */
   public JavaRuntime registerJavaRuntime(String id, File location) {
-    return registerJavaRuntime(id, location, null, null, null);
+    return registerJavaRuntime(id, location, null, null, null, null);
 
   }
 
@@ -67,16 +67,17 @@ public class JavaRuntimeRegistryImpl implements JavaRuntimeRegistry {
    * (non-Javadoc)
    * 
    * @see org.ant4eclipse.lib.jdt.model.jre.JavaRuntimeRegistry#registerJavaRuntime(java.lang.String, java.io.File,
-   * java.util.List)
+   * java.util.List, java.lang.String)
    */
   public JavaRuntime registerJavaRuntime(String id, File location, String extDirs, String endorsedDirs,
-      List<File> jreFiles) {
+      List<File> jreFiles, String profile) {
     Assure.nonEmpty("id", id);
     Assure.isDirectory("location", location);
-    A4ELogging.info("registerJavaRuntime: id = %s, location = %s, extDirs = %s, endorsedDirs = %s, jreFiles = %s", id,
-        location, extDirs, endorsedDirs, jreFiles);
+    A4ELogging.info(
+        "registerJavaRuntime: id = %s, location = %s, extDirs = %s, endorsedDirs = %s, jreFiles = %s, profile = %s", id,
+        location, extDirs, endorsedDirs, jreFiles, profile);
 
-    JavaRuntime javaRuntime = JavaRuntimeLoader.loadJavaRuntime(id, location, extDirs, endorsedDirs, jreFiles);
+    JavaRuntime javaRuntime = JavaRuntimeLoader.loadJavaRuntime(id, location, extDirs, endorsedDirs, jreFiles, profile);
 
     return registerJavaRuntime(javaRuntime);
   }
@@ -349,6 +350,6 @@ public class JavaRuntimeRegistryImpl implements JavaRuntimeRegistry {
 
     // create new java runtime
     A4ELogging.info("Using default JRE defined in system property 'java.home' (%s)", location.getAbsolutePath());
-    return JavaRuntimeLoader.loadJavaRuntime("java.home", location, null, null, null);
+    return JavaRuntimeLoader.loadJavaRuntime("java.home", location, null, null, null, null);
   }
 }

--- a/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/model/jre/JavaRuntimeRegistry.java
+++ b/org.ant4eclipse.lib.jdt/src/org/ant4eclipse/lib/jdt/model/jre/JavaRuntimeRegistry.java
@@ -40,9 +40,12 @@ public interface JavaRuntimeRegistry {
    * @param location
    * @param jreFiles
    *          the jreFiles that define the jre or null
+   * @param profile
+   *          Optional profile name to use instead of the detected profile name.
    * @return
    */
-  JavaRuntime registerJavaRuntime(String id, File location, String extDirs, String endorsedDirs, List<File> jreFiles);
+  JavaRuntime registerJavaRuntime(String id, File location, String extDirs, String endorsedDirs, List<File> jreFiles,
+      String profile);
 
   /**
    * <p>


### PR DESCRIPTION
Hi,

still happily building with ant and ant4eclipse. Recently tried to migrate our project to Java 11, but unfortunately, ant4eclipse crashes with the following error - the Java version string format seems to have changed:

```
org.ant4eclipse.lib.core.exception.Ant4EclipseException: An invalid
format has been used: The given version '11.0.9.1' is invalid. Must
match: <major> [ '.' <minor> [ '.' <micro> [ '_' <qualifier> ] ] ]
```

I fixed this problem - see commits. But unfortunately the next error is:

```
org.ant4eclipse.lib.core.exception.Ant4EclipseException: The JRE with id 'JavaSE-11' at '/usr/lib/jvm/java-11-openjdk-amd64' has VM Profile 'JavaSE-11' but that profile is unknown.
```

I found these profile files e.g. `/ant4eclipse/org.ant4eclipse.lib.jdt/src/profiles/JavaSE-9.profile` where a Java 11 profile seems to be missing. Unfortunately, I have no clue where to get a `JavaSE-11.profile` from - looks like copied from an Eclipse version? Could you give me a hint, how to proceed?